### PR TITLE
Enable @npmcorp scoped components

### DIFF
--- a/src/update-asset-urls-and-concat.js
+++ b/src/update-asset-urls-and-concat.js
@@ -14,7 +14,7 @@ export default function updateAssetUrlsAndConcat() {
 
   const resultCssFileStream = map(function({renameTable, files}, callback) {
     const concatenatedCss = files.reduce((cssContents, file) => {
-      const {assetLocationTranslation} = renameTable[file.packageName];
+      const {assetLocationTranslation} = renameTable[file.packageName] || renameTable['@npmcorp/' + file.packageName];
       let cssWithUpdatedPaths = file.contents.toString();
       for (let originalUrl of Object.keys(assetLocationTranslation)) {
         const newUrl = assetLocationTranslation[originalUrl];


### PR DESCRIPTION
This change allows us to add scoped modules to pivotal-ui, work with them like every other pui component, and still publish them as scoped modules (which is part of the pui system).

This is definitely a hack. I'm not sure how to test it yet, but I want to put it up before we forget about it :-)
